### PR TITLE
Add quotes

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -131,7 +131,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public static function findByEmailOrUserName($email)
     {
-        return static::find()->where(['and', 'status=:status', ['or', 'email=:email', 'username=:username']], [':status' => self::STATUS_ACTIVE, ':email' => $email, ':username' => $email])->one();
+        return static::find()->where(['and', '"status"=:status', ['or', '"email"=:email', '"username"=:username']], [':status' => self::STATUS_ACTIVE, ':email' => $email, ':username' => $email])->one();
     }
 
     /**


### PR DESCRIPTION
Trouble to make request on oracle DB without quotes on column name.

Request look like:
SELECT * FROM "user" WHERE (status=2) AND ((email='XXXXX') OR (username='XXXXX'));

Get 904 error (invalid identifier).

With proposed changes request will look like (login normally):
SELECT * FROM "user" WHERE ("status"=2) AND (("email"='XXXXX') OR ("username"='XXXXX'));

Environment:
Ubuntu 16.04.
Apache/2.4.18.
Oracle 12.2

Not tested this solution with another DB's, but with this DB looks fixed.